### PR TITLE
Add prefix flag to selectively copy contents from bucket

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This creates a devtoolsslackbot binary which you can run by
 ```
 export AWS_PROFILE=<profile> # set if you need to use a non-default profile.
 export AWS_REGION=<region> 
-./s3copier -bucket=<bucketname> -baseDir=<path> -concurrency=<number of concurrent connections to use> -queueSize=<number of keys to queue up to copy>
+./s3copier -bucket=<bucketname> -baseDir=<path> -concurrency=<number of concurrent connections to use> -queueSize=<number of keys to queue up to copy> -prefix=<bucket prefix to copy from>
 ```
 
 To build a LINUX binary on Mac


### PR DESCRIPTION
Example use case:
You have a bucket with a prefix per day, and only want to download the contents for a single day.